### PR TITLE
Add RBAC enforcement for API endpoints and proxy routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,15 @@ Edit `config.yml` to configure:
         actions: [read]
   ```
 
-- **Proxies**: Configure request routing to backend services
+- **Proxies**: Configure request routing to backend services and optional RBAC enforcement
   ```yaml
   proxy:
     - endpoint: /api/data
       target: http://backend-service/
       rewrite: ""  # Currently unused, kept for future compatibility
       change_origin: true  # If true, updates the Host header to match target
+      required_resource: data
+      required_actions: [read]
   ```
 
   The proxy will forward requests from `{endpoint}/*` to `{target}/*` with the same path. For example, a request to `/api/data/items` will be forwarded to `http://backend-service/api/data/items`.
@@ -125,7 +127,10 @@ The gateway forwards tenant information to backend services via HTTP headers:
 
 - **`X-Tenant-ID`**: Contains the tenant ID from the JWT token, enabling backend services to enforce tenant isolation
 
-Note: Role information is currently only available in the JWT token itself. Backend services should decode the JWT to access role information for authorization decisions.
+RBAC enforcement happens in two places:
+
+- **API endpoints**: Each endpoint defines the required resource/action. For example, `GET /api/v1/users/me` requires `users:read`.
+- **Proxy routes**: Each proxy entry can declare `required_resource` and `required_actions` to authorize requests before forwarding.
 
 Example configuration:
 
@@ -146,6 +151,8 @@ proxy:
     target: http://localhost:3000
     rewrite: ""
     change_origin: true
+    required_resource: data
+    required_actions: [read, execute]
 ```
 
 ## Configuration

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -36,5 +36,23 @@ async def get_current_user_dependency(
     from app.core.security import get_current_user
     return await get_current_user(token, config)
 
+def require_permission(resource: str, action: str):
+    """
+    Factory for a dependency that enforces RBAC permissions.
+
+    Args:
+        resource: Resource name to authorize
+        action: Action to authorize
+    """
+    async def _permission_dependency(
+        current_user: TokenPayload = Depends(get_current_user_dependency),
+        config: AppConfig = Depends(get_config)
+    ) -> TokenPayload:
+        from app.core.security import authorize_request
+        authorize_request(current_user.roles, resource, action, config)
+        return current_user
+
+    return _permission_dependency
+
 # Alias for backwards compatibility
 get_current_active_user = get_current_user_dependency

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -3,13 +3,13 @@ from typing import List
 
 from app.models.schemas import UserResponse, TokenPayload
 from app.models.config_models import AppConfig, User
-from app.api.deps import get_current_active_user, get_config
+from app.api.deps import get_current_active_user, get_config, require_permission
 
 router = APIRouter()
 
 @router.get("/me", response_model=UserResponse)
 async def read_users_me(
-    current_user: TokenPayload = Depends(get_current_active_user),
+    current_user: TokenPayload = Depends(require_permission("users", "read")),
     config: AppConfig = Depends(get_config)
 ):
     """Get current user information"""

--- a/app/models/config_models.py
+++ b/app/models/config_models.py
@@ -1,6 +1,6 @@
 import logging
 from pydantic import BaseModel, Field, ValidationError
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +12,8 @@ class ProxyConfig(BaseModel):
     target: str
     rewrite: str = ""
     change_origin: bool = False
+    required_resource: Optional[str] = None
+    required_actions: List[str] = Field(default_factory=list)
 
 class User(BaseModel):
     name: str

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,6 +11,8 @@ proxy:
         target: http://graph-composer:8000/
         rewrite: ""
         change_origin: true
+        required_resource: graphs
+        required_actions: [read, execute]
 
 users:
     # Passwords can be plaintext or bcrypt hashed (recommended)
@@ -29,16 +31,21 @@ roles:
   admin:
     - resource: "tenants"
       actions: [read, write, create, delete]
+    - resource: "users"
+      actions: [read]
   tenant_admin:
     - resource: "users"
       actions: [ read, write, create, delete ]
   editor:
     - resource: graphs
       actions: [create, read, update, delete, execute]
+    - resource: "users"
+      actions: [read]
   viewer:
     - resource: graphs
       actions: [read]
-
+    - resource: "users"
+      actions: [read]
 
 
 

--- a/tests/api/v1/test_rbac.py
+++ b/tests/api/v1/test_rbac.py
@@ -92,6 +92,19 @@ class TestRoleBasedAccessControl:
         assert data["tenant_id"] == TestConstants.TEST_TENANT, \
             f"Expected tenant {TestConstants.TEST_TENANT}, got {data.get('tenant_id')}"
 
+    def test_user_missing_permission_gets_forbidden(self):
+        """Test that users without permissions receive 403 responses."""
+        token = self._get_auth_token(TestConstants.LIMITED_USER, TestConstants.LIMITED_PASSWORD)
+        headers = TestDataFactory.create_auth_headers(token)
+
+        response = self.client.get(
+            TestConstants.ENDPOINTS["USER_ME"],
+            headers=headers
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, \
+            f"Expected 403 for missing permissions, got {response.status_code}"
+
     def test_unauthorized_access(self):
         """Test that unauthorized requests are properly rejected."""
         response = self.client.get(TestConstants.ENDPOINTS["USER_ME"])

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -16,6 +16,9 @@ class TestConstants:
     
     VIEWER_USER = "viewer_user"
     VIEWER_PASSWORD = "viewerpass"
+
+    LIMITED_USER = "limited_user"
+    LIMITED_PASSWORD = "limitedpass"
     
     # API endpoints
     ENDPOINTS = {
@@ -35,4 +38,5 @@ class TestConstants:
         "ADMIN": "admin",
         "EDITOR": "editor", 
         "VIEWER": "viewer",
+        "LIMITED": "limited",
     }

--- a/tests/fixtures/test_config.yml
+++ b/tests/fixtures/test_config.yml
@@ -9,6 +9,8 @@ proxy:
     target: http://test-server/
     rewrite: ""
     change_origin: true
+    required_resource: graphs
+    required_actions: [read]
 
 users:
   - name: testuser
@@ -25,17 +27,31 @@ users:
     password: viewerpass  # Using plaintext for testing
     roles: [viewer]
     tenant_id: test-tenant
+    
+  - name: limited_user
+    password: limitedpass  # Using plaintext for testing
+    roles: [limited]
+    tenant_id: test-tenant
 
 roles:
   admin:
     - resource: "tenants"
       actions: [read, write, create, delete]
+    - resource: "users"
+      actions: [read]
   tenant_admin:
     - resource: "users"
       actions: [read, write, create, delete]
   editor:
     - resource: graphs
       actions: [create, read, update, delete, execute]
+    - resource: "users"
+      actions: [read]
   viewer:
+    - resource: graphs
+      actions: [read]
+    - resource: "users"
+      actions: [read]
+  limited:
     - resource: graphs
       actions: [read]


### PR DESCRIPTION
### Motivation

- Introduce role-based access control checks so API endpoints and proxied routes can enforce resource/action permissions defined in configuration.
- Use existing `AppConfig.roles` definitions to drive authorization decisions rather than ad-hoc checks in handlers/middleware.
- Provide a simple dependency for endpoints and a config-driven enforcement point for proxy routes to centralize authorization logic.

### Description

- Add authorization helper in `app/core/security.py`: `authorize_request(user_roles, resource, action, config)` and helper `_permission_allows` to evaluate permissions.
- Extend `ProxyConfig` in `app/models/config_models.py` with `required_resource` and `required_actions` to declare per-proxy RBAC requirements.
- Add `require_permission(resource, action)` dependency factory in `app/api/deps.py` and replace the `GET /api/v1/users/me` dependency with `Depends(require_permission("users", "read"))` to enforce endpoint RBAC.
- Enforce proxy RBAC in `app/core/middleware.py` by checking `proxy_config.required_resource`/`required_actions` and calling `authorize_request` before forwarding requests; handle `HTTPException` responses from authorization.
- Update example configs (`config/config.yml`, `tests/fixtures/test_config.yml`), add a limited-role test user and role, update tests constants, and document proxy RBAC and enforcement in `README.md`.

### Testing

- Modified/added tests: `tests/api/v1/test_rbac.py` (adds `test_user_missing_permission_gets_forbidden`) and updated test fixtures in `tests/fixtures/test_config.yml`.
- Attempted to run: `pytest tests/api/v1/test_rbac.py -q` — failed in this environment with `ModuleNotFoundError: No module named 'fastapi'` (test environment missing dependencies).
- Note: With project dependencies installed (FastAPI, httpx, jose, etc.) the updated RBAC tests should be runnable in CI or a local dev environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694527d69e8c8321a68ecd17dd4c14f8)