### PR TITLE
Expand proxy and config validation coverage

### DIFF
--- a/app/models/config_models.py
+++ b/app/models/config_models.py
@@ -1,5 +1,5 @@
 import logging
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from typing import List, Dict, Any
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,31 @@ class AppConfig(BaseModel):
     users: List[User] = Field(default_factory=list)
     roles: Dict[str, List[Permission]] = Field(default_factory=dict)
     default_config: bool = False
+
+    @model_validator(mode="after")
+    def validate_user_references(self) -> "AppConfig":
+        """Ensure user references to tenants and roles are valid."""
+        tenant_ids = {tenant.id for tenant in self.tenants}
+        defined_roles = set(self.roles.keys())
+        errors: list[str] = []
+
+        for user in self.users:
+            if tenant_ids and user.tenant_id not in tenant_ids:
+                errors.append(
+                    f"user '{user.name}' references undefined tenant_id '{user.tenant_id}'"
+                )
+
+            missing_roles = [role for role in user.roles if role not in defined_roles]
+            if missing_roles:
+                missing_roles_str = ", ".join(missing_roles)
+                errors.append(
+                    f"user '{user.name}' references undefined roles: {missing_roles_str}"
+                )
+
+        if errors:
+            raise ValueError("; ".join(errors))
+
+        return self
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> 'AppConfig':

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,73 @@
+import pytest
+from pydantic import ValidationError
+
+from app.main import create_application
+from app.models.config_models import AppConfig
+
+
+def test_app_config_rejects_user_with_unknown_tenant():
+    config_data = {
+        "tenants": [{"id": "tenant-a"}],
+        "users": [
+            {
+                "name": "alice",
+                "password": "secret",
+                "tenant_id": "tenant-missing",
+                "roles": ["viewer"],
+            }
+        ],
+        "roles": {
+            "viewer": [{"resource": "graph", "actions": ["read"]}]
+        },
+        "proxy": [],
+    }
+
+    with pytest.raises(ValidationError):
+        AppConfig.from_dict(config_data)
+
+
+def test_app_config_rejects_user_with_unknown_role():
+    config_data = {
+        "tenants": [{"id": "tenant-a"}],
+        "users": [
+            {
+                "name": "alice",
+                "password": "secret",
+                "tenant_id": "tenant-a",
+                "roles": ["missing-role"],
+            }
+        ],
+        "roles": {
+            "viewer": [{"resource": "graph", "actions": ["read"]}]
+        },
+        "proxy": [],
+    }
+
+    with pytest.raises(ValidationError):
+        AppConfig.from_dict(config_data)
+
+
+def test_create_application_fails_fast_on_invalid_config(monkeypatch, tmp_path):
+    config_path = tmp_path / "invalid-config.yml"
+    config_path.write_text(
+        """
+tenants:
+  - id: tenant-a
+users:
+  - name: alice
+    password: secret
+    tenant_id: tenant-missing
+    roles: [viewer]
+roles:
+  viewer:
+    - resource: graph
+      actions: [read]
+proxy: []
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("CONFIG_FILE", str(config_path))
+
+    with pytest.raises(ValidationError):
+        create_application()


### PR DESCRIPTION
## Summary
This PR closes the test-coverage gaps identified after RBAC/tenant-binding work.

### What changed
1. Proxy route precedence is now deterministic and specific:
- updated proxy matching to choose the most specific matching endpoint (longest prefix)
- added path-boundary matching so `/api/v1/graph` does not accidentally match `/api/v1/graphical`

2. Config validation is now stricter at load/startup:
- added model-level validation that each user references:
  - a defined tenant (`tenant_id`)
  - only defined roles
- invalid config now fails fast during app creation/config parsing

3. Expanded proxy test coverage:
- overlapping route precedence behavior
- endpoint prefix boundary behavior
- explicit `proxy.resource` override behavior in both authorization helper and request flow
- HTTP method/action RBAC mapping edge cases (`HEAD`, `OPTIONS`, `PATCH`, `DELETE` allow/deny paths)

4. Added startup/config validation tests:
- rejects unknown tenant references
- rejects unknown role references
- verifies `create_application()` fails on invalid config

## Files changed
- `app/core/middleware.py`
- `app/models/config_models.py`
- `tests/test_proxy.py`
- `tests/test_config_models.py` (new)

## Validation
- Ran full suite: `uv run pytest tests/ -q`
- Result: `62 passed, 0 failed`

## Notes
- This branch is intentionally stacked on top of `agent/rbac-tenant-binding`.
