### PR TITLE
Fix package readiness and proxy rewrite behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV CONFIG_FILE=/app/config/config.yml \
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD uv run python -c "import requests; requests.get('http://localhost:8000/health')" || exit 1
+    CMD uv run python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)" || exit 1
 
 # Run the application using uv
-CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -99,11 +99,15 @@ Edit `config.yml` to configure:
   proxy:
     - endpoint: /api/data
       target: http://backend-service/
-      rewrite: ""  # Currently unused, kept for future compatibility
+      rewrite: /data
       change_origin: true  # If true, updates the Host header to match target
   ```
 
-  The proxy will forward requests from `{endpoint}/*` to `{target}/*` with the same path. For example, a request to `/api/data/items` will be forwarded to `http://backend-service/api/data/items`.
+  The proxy will forward requests from `{endpoint}/*` to `{target}{rewrite}/*` by replacing the endpoint prefix.
+  If `rewrite` is omitted or empty, the original request path is preserved.
+  For example, request `/api/data/items`:
+  - with `rewrite: /data` => `http://backend-service/data/items`
+  - with `rewrite: ""` => `http://backend-service/api/data/items`
 
 ### Tenant ID in JWT Tokens
 
@@ -194,11 +198,15 @@ If you prefer to run without Docker:
 
 2. Run the service:
    ```bash
-   uv run uvicorn main:app --reload
+   uv run uvicorn app.main:app --reload
+   ```
+   or
+   ```bash
+   uv run tiny-gateway
    ```
 
 ### Environment Variables
-- `CONFIG_FILE`: Path to configuration file (default: `config/config.yml`)
+- `CONFIG_FILE`: Path to configuration file (default: packaged `app/resources/default_config.yml`)
 - `SECRET_KEY`: JWT signing key (default: development key)  
 - `ACCESS_TOKEN_EXPIRE_MINUTES`: Token expiration time (default: 30)
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,56 +1,70 @@
-import os
-import yaml
 import logging
+import os
 from contextlib import asynccontextmanager
+from pathlib import Path
+
+import yaml
 from fastapi import FastAPI
 from starlette.responses import FileResponse
 
-from app.core.middleware import ProxyMiddleware
 from app.api.api import api_router
 from app.config.settings import settings
+from app.core.middleware import ProxyMiddleware
 from app.models.config_models import AppConfig
 
 logger = logging.getLogger(__name__)
 
+PACKAGE_DIR = Path(__file__).resolve().parent
+RESOURCE_DIR = PACKAGE_DIR / "resources"
+DEFAULT_CONFIG_FILE = RESOURCE_DIR / "default_config.yml"
+LOGIN_PAGE_FILE = RESOURCE_DIR / "index.html"
+
+
+def _resolve_config_path() -> Path:
+    configured_path = os.getenv("CONFIG_FILE")
+    if configured_path:
+        return Path(configured_path).expanduser().resolve()
+    return DEFAULT_CONFIG_FILE
+
+
+def _load_config() -> AppConfig:
+    config_path = _resolve_config_path()
+
+    try:
+        with config_path.open("r", encoding="utf-8") as config_file:
+            config_data = yaml.safe_load(config_file) or {}
+        config = AppConfig.from_dict(config_data)
+        logger.info("Configuration loaded from %s", config_path)
+    except FileNotFoundError:
+        logger.error("Configuration file not found: %s", config_path)
+        raise
+    except yaml.YAMLError as exc:
+        logger.error("Error parsing YAML configuration: %s", exc)
+        raise
+
+    if config.default_config:
+        logger.warning(
+            "The service is using the default config and that's probably not intended. "
+            "Remove the default_config flag in your version."
+        )
+
+    return config
+
 
 def create_application() -> FastAPI:
     """Create and configure the FastAPI application."""
-    # Configure logging first
     settings.configure_logging()
-    
-    # Get config file path from environment variable or use default
-    config_path = os.getenv("CONFIG_FILE", "config/config.yml")
-    
-    # Load configuration
-    try:
-        with open(config_path, "r") as f:
-            config_data = yaml.safe_load(f)
-        config = AppConfig.from_dict(config_data)
-        logger.info(f"Configuration loaded from {config_path}")
-        
-        # Check for default configuration and warn
-        if config.default_config:
-            logger.warning(
-                "The service is using the default config and that's probably not intended. "
-                "Remove the default_config flag in your version."
-            )
-    except FileNotFoundError:
-        logger.error(f"Configuration file not found: {config_path}")
-        raise
-    except yaml.YAMLError as e:
-        logger.error(f"Error parsing YAML configuration: {e}")
-        raise
-    
+    config = _load_config()
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        """Manage application lifecycle events."""        
+        """Manage application lifecycle events."""
         logger.info("Starting up API Gateway...")
-        
-        # Store config in app state for reuse across requests
+
         app.state.config = config
-        
-        # Create shared HTTP client for middleware
+
         import httpx
+
         shared_client = httpx.AsyncClient(
             timeout=30.0,
             limits=httpx.Limits(
@@ -62,46 +76,49 @@ def create_application() -> FastAPI:
             follow_redirects=False,
         )
         app.state.http_client = shared_client
-        
+
         logger.info("Configuration and HTTP client initialized")
-        
-        yield  # Application is running
-        
-        # Shutdown: Clean up shared resources
+
+        yield
+
         logger.info("Shutting down API Gateway...")
         await shared_client.aclose()
         logger.info("HTTP client closed successfully")
-    
-    # Create FastAPI app with lifespan management
+
     app = FastAPI(
         title=settings.PROJECT_NAME,
         openapi_url=f"{settings.API_V1_STR}/openapi.json",
-        lifespan=lifespan
+        lifespan=lifespan,
     )
-    
-    # Add proxy middleware
+
     app.add_middleware(ProxyMiddleware, config=config)
-    
-    # Include API router
     app.include_router(api_router)
-    
-    # Health check endpoint
+
     @app.get("/health")
     async def health_check():
         """Health check endpoint for monitoring."""
         return {"status": "healthy"}
-    
-    # Serve login page
+
     @app.get("/test_login")
     async def read_index():
         """Serve the login web page."""
-        return FileResponse('index.html')
-    
+        return FileResponse(LOGIN_PAGE_FILE)
+
     return app
+
+
+def run() -> None:
+    """CLI entrypoint for running the gateway."""
+    import uvicorn
+
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload_enabled = os.getenv("RELOAD", "").lower() in {"1", "true", "yes"}
+    uvicorn.run("app.main:app", host=host, port=port, reload=reload_enabled)
 
 
 app = create_application()
 
-# if __name__ == "__main__":
-#     import uvicorn
-#     uvicorn.run(app, host="0.0.0.0", port=8000)
+
+if __name__ == "__main__":
+    run()

--- a/app/resources/default_config.yml
+++ b/app/resources/default_config.yml
@@ -1,0 +1,44 @@
+# WARNING: This is a default configuration file for development/testing only
+# Remove the default_config and customize for your environment
+default_config: true
+
+tenants:
+  - id: evil-corp
+  - id: wayland-yutani
+
+proxy:
+      - endpoint: /api/v1/graph
+        target: http://graph-composer:8000/
+        rewrite: ""
+        change_origin: true
+
+users:
+    # Passwords can be plaintext or bcrypt hashed (recommended)
+    # To generate bcrypt hash: python -c "from passlib.context import CryptContext; print(CryptContext(schemes=['bcrypt']).hash('your_password'))"
+    # Example bcrypt hash: $2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPj8fq5ljPOq6
+    - name: paul
+      password: cleverpass123  # plaintext password 
+      roles: [ tenant_admin, editor]
+      tenant_id: evil-corp
+    - name: someone
+      password: anyone123  # plaintext password 
+      roles: [editor]
+      tenant_id: wayland-yutani
+
+roles:
+  admin:
+    - resource: "tenants"
+      actions: [read, write, create, delete]
+  tenant_admin:
+    - resource: "users"
+      actions: [ read, write, create, delete ]
+  editor:
+    - resource: graphs
+      actions: [create, read, update, delete, execute]
+  viewer:
+    - resource: graphs
+      actions: [read]
+
+
+
+

--- a/app/resources/index.html
+++ b/app/resources/index.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tiny Gateway - Login</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            text-align: center;
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            box-sizing: border-box;
+        }
+        button {
+            background-color: #007bff;
+            color: white;
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        button:disabled {
+            background-color: #6c757d;
+            cursor: not-allowed;
+        }
+        .result {
+            margin-top: 20px;
+            padding: 15px;
+            border-radius: 4px;
+        }
+        .success {
+            background-color: #d4edda;
+            border: 1px solid #c3e6cb;
+            color: #155724;
+        }
+        .error {
+            background-color: #f8d7da;
+            border: 1px solid #f5c6cb;
+            color: #721c24;
+        }
+        pre {
+            background-color: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+            white-space: pre-wrap;
+        }
+        .section {
+            margin-top: 20px;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        .section h3 {
+            margin-top: 0;
+            color: #495057;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🔐 Tiny Gateway Login</h1>
+        
+        <form id="loginForm">
+            <div class="form-group">
+                <label for="username">Username:</label>
+                <input type="text" id="username" name="username" required>
+            </div>
+            
+            <div class="form-group">
+                <label for="password">Password:</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            
+            <button type="submit" id="loginBtn">Login</button>
+        </form>
+        
+        <div id="result"></div>
+    </div>
+
+    <script>
+        const loginForm = document.getElementById('loginForm');
+        const loginBtn = document.getElementById('loginBtn');
+        const resultDiv = document.getElementById('result');
+
+        loginForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            
+            loginBtn.disabled = true;
+            loginBtn.textContent = 'Logging in...';
+            resultDiv.innerHTML = '';
+            
+            try {
+                // Step 1: Login to get token
+                const loginResponse = await fetch('/api/v1/auth/login', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: new URLSearchParams({
+                        username: username,
+                        password: password
+                    })
+                });
+
+                if (!loginResponse.ok) {
+                    const errorData = await loginResponse.json();
+                    throw new Error(errorData.detail || 'Login failed');
+                }
+
+                const loginData = await loginResponse.json();
+                const token = loginData.access_token;
+
+                // Step 2: Get user info using the token
+                const meResponse = await fetch('/api/v1/users/me', {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': `Bearer ${token}`,
+                        'Content-Type': 'application/json'
+                    }
+                });
+
+                if (!meResponse.ok) {
+                    const errorData = await meResponse.json();
+                    throw new Error(errorData.detail || 'Failed to get user info');
+                }
+
+                const meData = await meResponse.json();
+
+                // Display success information
+                displaySuccess(loginData, meResponse.headers, meData);
+
+            } catch (error) {
+                displayError(error.message);
+            } finally {
+                loginBtn.disabled = false;
+                loginBtn.textContent = 'Login';
+            }
+        });
+
+        function displaySuccess(loginData, responseHeaders, userData) {
+            const headersObj = {};
+            for (let [key, value] of responseHeaders.entries()) {
+                headersObj[key] = value;
+            }
+
+            resultDiv.innerHTML = `
+                <div class="result success">
+                    <h2>✅ Login Successful!</h2>
+                    
+                    <div class="section">
+                        <h3>🎫 Session Info (JWT Token)</h3>
+                        <pre>${JSON.stringify(loginData, null, 2)}</pre>
+                    </div>
+                    
+                    <div class="section">
+                        <h3>📋 Response Headers (/api/v1/users/me)</h3>
+                        <pre>${JSON.stringify(headersObj, null, 2)}</pre>
+                    </div>
+                    
+                    <div class="section">
+                        <h3>👤 User Information (/api/v1/users/me)</h3>
+                        <pre>${JSON.stringify(userData, null, 2)}</pre>
+                    </div>
+
+                    <div class="section">
+                        <h3>🔑 Decoded Token Info</h3>
+                        <pre>${decodeJWT(loginData.access_token)}</pre>
+                    </div>
+                </div>
+            `;
+        }
+
+        function displayError(message) {
+            resultDiv.innerHTML = `
+                <div class="result error">
+                    <h2>❌ Login Failed</h2>
+                    <p><strong>Error:</strong> ${message}</p>
+                </div>
+            `;
+        }
+
+        function decodeJWT(token) {
+            try {
+                const base64Url = token.split('.')[1];
+                const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+                const jsonPayload = decodeURIComponent(
+                    atob(base64)
+                        .split('')
+                        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+                        .join('')
+                );
+                return JSON.stringify(JSON.parse(jsonPayload), null, 2);
+            } catch (e) {
+                return 'Error decoding token: ' + e.message;
+            }
+        }
+
+        // Pre-fill with default credentials for convenience
+        document.getElementById('username').value = 'paul';
+        document.getElementById('password').value = 'cleverpass123';
+    </script>
+</body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - gateway-network
     # Add health check
     healthcheck:
-      test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8000/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/main.py
+++ b/main.py
@@ -1,8 +1,7 @@
-from app.main import app
+from app.main import app, run
 
 # This file is kept for backward compatibility
 # The main application is now in app/main.py
 
 if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
   "pydantic-settings>=2.10.1",
 ]
 
+[project.scripts]
+tiny-gateway = "app.main:run"
+
 # Use this if you prefer groups over extras (recommended for dev-only deps)
 [dependency-groups]
 dev = [
@@ -22,12 +25,15 @@ dev = [
   "pytest-asyncio>=1.1.0"
 ]
 
-# If you want to ship a test extra instead, keep your section below and
-# install with: uv run --extra test pytest
-# [project.optional-dependencies]
-# test = ["pytest>=7.4.0", "pytest-cov>=4.1.0"]
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
 
-# Uncomment if you want the project to be installable / expose scripts
-# [build-system]
-# requires = ["setuptools>=61"]
-# build-backend = "setuptools.build_meta"
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["app*"]
+
+[tool.setuptools.package-data]
+app = ["resources/*.html", "resources/*.yml"]


### PR DESCRIPTION
## Summary

This PR fixes the package-readiness and runtime portability gaps so the gateway can be used reliably outside this repo layout.

## What Changed

### 1) Packaging/installability
- Added explicit build backend and packaging configuration in `pyproject.toml`.
- Added console entrypoint:
  - `tiny-gateway = app.main:run`
- Configured package data inclusion for bundled resources under `app/resources/*`.

### 2) CWD-independent startup and resources
- Reworked app boot logic in `app/main.py`:
  - Uses packaged default config when `CONFIG_FILE` is not set.
  - Resolves config path robustly.
  - Serves `/test_login` from packaged HTML resource, not from relative filesystem path.
- Added packaged resources:
  - `app/resources/default_config.yml`
  - `app/resources/index.html`
- Updated compatibility launcher in `main.py` to call `run()`.

### 3) Removed hidden healthcheck dependency
- Replaced `requests`-based healthcheck probes with stdlib `urllib.request` in:
  - `Dockerfile`
  - `docker-compose.yml`

### 4) Implemented rewrite functionality
- Implemented real `rewrite` behavior in proxy middleware:
  - Endpoint prefix replacement for target path construction.
  - Preserves old behavior when `rewrite` is empty.
- Updated debug target URL logging to reflect rewritten target path.

### 5) Docs alignment
- Updated README examples and behavior notes:
  - `rewrite` semantics now documented accurately.
  - Run command standardized to `uvicorn app.main:app`.
  - Added `uv run tiny-gateway` usage.
  - Updated default `CONFIG_FILE` description.

## Tests Added/Updated

- Added tests for CWD-independent app startup and login page resource serving.
- Added tests for proxy rewrite path behavior.
- Existing suite updated to remain consistent with new behavior.

## Validation

- Ran full test suite:
  - `./.venv/bin/python -m pytest tests/ -q`
  - Result: `82 passed`

- Manual smoke check from outside repo CWD (`/tmp`) confirmed:
  - `/health` returns 200
  - `/test_login` returns 200

## Notes

- The code now supports package-style usage paths and resource loading without relying on repository-relative file locations.
