### PR TITLE
Align proxy behavior and docs for query params and error semantics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build Release Distributions
+    name: Build Release Distribution
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ What Tiny Gateway gives you out-of-the-box:
 - automatic `X-Tenant-ID` forwarding upstream
 
 If you already have a production-grade authn/authz stack, Traefik/NGINX + external identity policy is often the better fit.
-If you want a single self-contained gateway for local dev teams, this project is optimized for that workflow.
+If you want a single self-contained gateway for local dev teams, this project is designed for that workflow.
 
 
 ## Quick Start
@@ -168,7 +168,7 @@ proxy:
 - `rewrite: ""` preserves external endpoint prefix
 - `rewrite: "/new-prefix"` replaces endpoint prefix
 - `change_origin: true` rewrites `Host` header to upstream host
-- query parameters are preserved and forwarded to the upstream service
+- query parameters (including repeated keys) are preserved and forwarded to the upstream service
 - upstream redirects (3xx) are passed through as-is (the gateway does not follow redirects)
 
 ### RBAC Mapping for Proxied Requests
@@ -198,21 +198,26 @@ python -c "from passlib.hash import bcrypt; print(bcrypt.using(rounds=12).hash('
 
 ### Upstream Connection
 
-The gateway connects to upstream services using HTTP/2 with connection pooling.
-Request bodies are limited to 10 MB by default.
+The gateway uses connection pooling and attempts HTTP/2 when the upstream supports it.
+Proxied request bodies are limited to 10 MB by default.
 
 ### Error Responses
 
-All gateway-generated errors are returned as JSON:
+Gateway errors are returned as JSON.
+Most error responses include a `detail` field:
 
 ```json
 {"detail": "error message"}
 ```
 
+For unmatched routes, the 404 response also includes `hint` and `endpoints` to make local debugging easier.
+
 | Status | Meaning |
 |--------|---------|
 | 401 | Missing, invalid, or expired token |
+| 404 | Route not found |
 | 403 | Insufficient role permissions |
+| 413 | Proxied request body too large |
 | 502 | Upstream service unreachable |
 | 504 | Upstream service timed out |
 | 500 | Unexpected internal error |

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -176,6 +176,48 @@ def test_proxy_middleware_applies_rewrite_prefix(test_app, mock_async_client):
     _, kwargs = mock_async_client.request.call_args
     assert kwargs["url"] == "http://test-server/graphs/items"
 
+
+def test_proxy_middleware_preserves_repeated_query_params(test_app, mock_async_client):
+    proxy_routes = [
+        ProxyConfig(
+            endpoint="/api/v1/graph",
+            target="http://test-server/",
+            rewrite="",
+            change_origin=True,
+        )
+    ]
+    test_user = User(
+        name="testuser",
+        password="testpassword",
+        tenant_id="test-tenant",
+        roles=["admin"],
+    )
+    admin_permission = Permission(resource="*", actions=["read", "write", "create", "update", "delete"])
+
+    test_app.add_middleware(
+        ProxyMiddleware,
+        config=AppConfig(
+            proxy=proxy_routes,
+            users=[test_user],
+            roles={"admin": [admin_permission]},
+            tenants=[{"id": "test-tenant"}],
+        ),
+        client=mock_async_client,
+    )
+
+    client = TestClient(test_app)
+    token = TestDataFactory.create_jwt_token()
+
+    response = client.get(
+        "/api/v1/graph/search?tag=a&tag=b&limit=10",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    _, kwargs = mock_async_client.request.call_args
+    assert kwargs["params"] == [("tag", "a"), ("tag", "b"), ("limit", "10")]
+
+
 def test_non_proxied_endpoint(test_app, proxy_config, mock_async_client):
     # Configure the test app with middleware and test config, passing the mock client
     test_app.add_middleware(
@@ -564,7 +606,7 @@ def test_proxy_rejects_oversized_request_body(test_app, mock_async_client):
         headers={"Authorization": f"Bearer {token}"},
     )
 
-    assert response.status_code == 401
+    assert response.status_code == 413
     assert "too large" in response.json()["detail"]
     mock_async_client.request.assert_not_called()
 

--- a/tiny_gateway/core/middleware.py
+++ b/tiny_gateway/core/middleware.py
@@ -12,6 +12,10 @@ from tiny_gateway.core.security import validate_token_and_get_payload
 logger = logging.getLogger(__name__)
 
 
+class RequestBodyTooLargeError(Exception):
+    """Raised when a proxied request body exceeds the configured size limit."""
+
+
 class ProxyMiddleware:
     """
     Middleware for proxying authenticated requests to backend services.
@@ -243,7 +247,7 @@ class ProxyMiddleware:
 
         body = await request.body()
         if len(body) > self.MAX_REQUEST_BODY_BYTES:
-            raise ValueError(
+            raise RequestBodyTooLargeError(
                 f"Request body too large ({len(body)} bytes, limit {self.MAX_REQUEST_BODY_BYTES})"
             )
 
@@ -251,7 +255,8 @@ class ProxyMiddleware:
             method=request.method,
             url=target_url,
             headers=headers,
-            params=dict(request.query_params),
+            # Preserve repeated query parameter keys (e.g., ?tag=a&tag=b).
+            params=list(request.query_params.multi_items()),
             content=body,
             follow_redirects=False
         )
@@ -325,6 +330,9 @@ class ProxyMiddleware:
         except ValueError as e:
             # Authentication or validation errors
             await self._send_error_response(send, 401, str(e))
+
+        except RequestBodyTooLargeError as e:
+            await self._send_error_response(send, 413, str(e))
             
         except httpx.ConnectError as e:
             # Connection errors to upstream service


### PR DESCRIPTION


This PR aligns implementation and docs so README claims are precise and non-aspirational.

### Code changes
- Preserve repeated query parameters when proxying (e.g. `?tag=a&tag=b`) instead of collapsing to a dict.
- Return `413` for oversized proxied request bodies (previously surfaced as `401` due to generic `ValueError` handling).
- Introduce a dedicated `RequestBodyTooLargeError` path in proxy middleware.

### Test changes
- Add proxy test coverage for repeated query parameter forwarding.
- Update oversized body test to assert `413`.

### Documentation changes
- Tone down wording from “optimized” to “designed” for local/dev workflow.
- Clarify query parameter forwarding includes repeated keys.
- Clarify HTTP/2 behavior as attempted/negotiated (when upstream supports it).
- Clarify 10 MB limit applies to proxied request bodies.
- Clarify error response shape/statuses, including:
  - `404` route-not-found responses may include `hint` and `endpoints`.
  - `413` for proxied request body too large.

## Validation

- `uv run pytest -q`
- Result: `98 passed`
```